### PR TITLE
Changed docs link in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,4 +17,4 @@ composer require league/flysystem-cached-adapter
 
 ## Usage
 
-[Check out the docs.](http://flysystem.thephpleague.com/caching/)
+[Check out the docs.](https://flysystem.thephpleague.com/docs/advanced/caching/)


### PR DESCRIPTION
the old URL is not longer valid, changed to https://flysystem.thephpleague.com/docs/advanced/caching/